### PR TITLE
fix deprecated imports from @noble/hashes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,8 @@
  *  limitations under the License.
  ******************************************************************************* */
 import type Transport from '@ledgerhq/hw-transport'
-import { ripemd160 } from '@noble/hashes/ripemd160'
-import { sha256 } from '@noble/hashes/sha256'
+import { ripemd160 } from '@noble/hashes/legacy.js'
+import { sha256 } from '@noble/hashes/sha2.js'
 import { bech32 } from '@scure/base'
 import BaseApp, {
   ERROR_DESCRIPTION_OVERRIDE,


### PR DESCRIPTION
#72 This package is phasing out the old imports starting with 1.8.0.

https://github.com/paulmillr/noble-hashes/releases/tag/1.8.0