### PR TITLE
feat: accept any transport that can send an APDU (DMK support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,9 @@
     "upgrade": "pnpm dlx npm-check-updates -i"
   },
   "dependencies": {
-    "@ledgerhq/hw-transport": "6.31.9",
     "@noble/hashes": "^1.8.0",
     "@scure/base": "^1.2.6",
-    "@zondax/ledger-js": "^1.3.1",
+    "@zondax/ledger-js": "github:Zondax/ledger-js#feat/dmk-transport",
     "buffer": "^6.0.3",
     "ripemd160": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@noble/hashes": "^1.8.0",
     "@scure/base": "^1.2.6",
-    "@zondax/ledger-js": "github:Zondax/ledger-js#feat/dmk-transport",
+    "@zondax/ledger-js": "^2.0.0",
     "buffer": "^6.0.3",
     "ripemd160": "^2.0.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.2.6
         version: 1.2.6
       '@zondax/ledger-js':
-        specifier: github:Zondax/ledger-js#feat/dmk-transport
-        version: https://codeload.github.com/Zondax/ledger-js/tar.gz/4e9cb4ced4c94de3ee036c2e60d23e152739682b
+        specifier: ^2.0.0
+        version: 2.0.0
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -773,9 +773,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@zondax/ledger-js@https://codeload.github.com/Zondax/ledger-js/tar.gz/4e9cb4ced4c94de3ee036c2e60d23e152739682b':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/Zondax/ledger-js/tar.gz/4e9cb4ced4c94de3ee036c2e60d23e152739682b}
-    version: 0.0.0
+  '@zondax/ledger-js@2.0.0':
+    resolution: {integrity: sha512-22dCyTbU38bZxRl7HpC2z1tQTfrbzOMy37PyzftBBK739GR2uBJ/EJy38gvuwwVHmX29e5tUa4MmJTsvUKQ2mg==}
     engines: {node: '>=20'}
 
   acorn-jsx@5.3.2:
@@ -2166,8 +2165,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-is@19.2.6:
-    resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+  react-is@19.3.0:
+    resolution: {integrity: sha512-UpMYezM4v5/18F28aC66AEsjXIgE02kyEMH6yLdgLXu/UTfa1Ntwck/nNLrbqJsEXW7gPb0coNO9FQse9WTovA==}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -3465,7 +3464,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@zondax/ledger-js@https://codeload.github.com/Zondax/ledger-js/tar.gz/4e9cb4ced4c94de3ee036c2e60d23e152739682b': {}
+  '@zondax/ledger-js@2.0.0': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -5103,7 +5102,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       ansi-styles: 5.2.0
       react-is-18: react-is@18.3.1
-      react-is-19: react-is@19.2.6
+      react-is-19: react-is@19.3.0
 
   process-nextick-args@2.0.1: {}
 
@@ -5125,7 +5124,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-is@19.2.6: {}
+  react-is@19.3.0: {}
 
   readable-stream@2.3.8:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@ledgerhq/hw-transport':
-        specifier: 6.31.9
-        version: 6.31.9
       '@noble/hashes':
         specifier: ^1.8.0
         version: 1.8.0
@@ -18,8 +15,8 @@ importers:
         specifier: ^1.2.6
         version: 1.2.6
       '@zondax/ledger-js':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: github:Zondax/ledger-js#feat/dmk-transport
+        version: https://codeload.github.com/Zondax/ledger-js/tar.gz/4e9cb4ced4c94de3ee036c2e60d23e152739682b
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -454,9 +451,6 @@ packages:
   '@ledgerhq/devices@8.14.2':
     resolution: {integrity: sha512-T3pnfrsQEC/eJU0XHIqWI6qww+CL1k3NumR2XGWlMz8lVpoZ9HhcuGoCkMevp+8SWmymgyNIIFue3jlNA5KiMw==}
 
-  '@ledgerhq/devices@8.5.0':
-    resolution: {integrity: sha512-zDB6Pdk6NYYbYis8cWoLLkL9k/IvjhC3hkuuz2lhpJ2AxIs3/PDMUKoyK4DpjPtRyKk1W1lwsnpc6J1i87r4/Q==}
-
   '@ledgerhq/errors@6.35.0':
     resolution: {integrity: sha512-qk9PbqIvze7NXGogVxNCsz60rNo5FrGj8gKqs7pcyDk+em5L6s70G7cRxR+1HTXdam4WoPfntUq+WX9zQUynkg==}
 
@@ -468,9 +462,6 @@ packages:
 
   '@ledgerhq/hw-transport-node-hid@6.33.2':
     resolution: {integrity: sha512-Vm2SRDN8FjQiT6vxhzd4EH8JeIH+UDT8NgNWU+iUpLuTllhd1sWHYsQ1Cc4MpUo7wSymqWlXaV3UsJKtYfRzRg==}
-
-  '@ledgerhq/hw-transport@6.31.9':
-    resolution: {integrity: sha512-HqB2Whl2qbrzyvs9gC/GmLhIy8RO4CWzjqHS4k0bPWDZRqKa8m6H32vjrbXGO//pUL1Mlu87UwvxvLyuICdjwg==}
 
   '@ledgerhq/hw-transport@6.35.2':
     resolution: {integrity: sha512-eSXFFqMDAB2Ra/5uqmlru0cUyc2XDQPEKf4ITWHeMms2fHhETw9lcgAEl61vszkiz0RLUVB4VQsLJjj7O8kCvg==}
@@ -782,8 +773,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@zondax/ledger-js@1.3.1':
-    resolution: {integrity: sha512-sDBwsunK2nSzkqJ5xi6QTiVVpAxSy+X1BVcMfKioBsInjktki2SezT7K8Hw6kSlYd3yfOJlw8cs+hqVtxpAGtg==}
+  '@zondax/ledger-js@https://codeload.github.com/Zondax/ledger-js/tar.gz/4e9cb4ced4c94de3ee036c2e60d23e152739682b':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/Zondax/ledger-js/tar.gz/4e9cb4ced4c94de3ee036c2e60d23e152739682b}
+    version: 0.0.0
+    engines: {node: '>=20'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3151,13 +3144,6 @@ snapshots:
       rxjs: 7.8.2
       semver: 7.7.3
 
-  '@ledgerhq/devices@8.5.0':
-    dependencies:
-      '@ledgerhq/errors': 6.35.0
-      '@ledgerhq/logs': 6.17.0
-      rxjs: 7.8.2
-      semver: 7.8.1
-
   '@ledgerhq/errors@6.35.0': {}
 
   '@ledgerhq/hw-transport-mocker@6.34.2':
@@ -3184,13 +3170,6 @@ snapshots:
       lodash: 4.18.1
       node-hid: 2.1.2
       usb: 2.9.0
-
-  '@ledgerhq/hw-transport@6.31.9':
-    dependencies:
-      '@ledgerhq/devices': 8.5.0
-      '@ledgerhq/errors': 6.35.0
-      '@ledgerhq/logs': 6.17.0
-      events: 3.3.0
 
   '@ledgerhq/hw-transport@6.35.2':
     dependencies:
@@ -3486,9 +3465,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@zondax/ledger-js@1.3.1':
-    dependencies:
-      '@ledgerhq/hw-transport': 6.31.9
+  '@zondax/ledger-js@https://codeload.github.com/Zondax/ledger-js/tar.gz/4e9cb4ced4c94de3ee036c2e60d23e152739682b': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,7 @@
 allowBuilds:
+  # Its package.json declares a `prepare` script, which pnpm asks about; a registry tarball
+  # never runs one, and it is no longer consumed from a git ref, so nothing needs building.
+  '@zondax/ledger-js': false
   node-hid: false
   unrs-resolver: false
   usb: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,7 @@ allowBuilds:
   node-hid: false
   unrs-resolver: false
   usb: false
+
+# First-party: pnpm 11's default 24h gate would fail CI until the tarball ages.
+minimumReleaseAgeExclude:
+  - '@zondax/ledger-js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ******************************************************************************* */
-import type Transport from '@ledgerhq/hw-transport'
 import { ripemd160 } from '@noble/hashes/legacy.js'
 import { sha256 } from '@noble/hashes/sha2.js'
 import { bech32 } from '@scure/base'
@@ -22,6 +21,7 @@ import BaseApp, {
   HARDENED,
   INSGeneric,
   LedgerError,
+  type LedgerTransport,
   PAYLOAD_TYPE,
   ResponseError,
   ResponsePayload,
@@ -70,7 +70,7 @@ export default class CosmosApp extends BaseApp {
    * @param transport - The transport instance.
    * @throws {Error} - If the transport is not defined.
    */
-  constructor(transport: Transport) {
+  constructor(transport: LedgerTransport) {
     super(transport, CosmosApp._params)
 
     if (!this.transport) {


### PR DESCRIPTION
## Why

Ledger deprecated LedgerJS — `@ledgerhq/hw-transport` and `@ledgerhq/hw-app-*` — in favour of the [Device Management Kit](https://www.ledger.com/blog-dmk-rollout). Their migration guide sanctions raw APDU via `dmk.sendApdu()` for chains without a DMK signer kit.

`CosmosApp extends BaseApp` and **only ever calls `send`** on the transport, so DMK support is a type change, not a rewrite.

## What

```diff
-import type Transport from '@ledgerhq/hw-transport'
-  constructor(transport: Transport) {
+  constructor(transport: LedgerTransport) {
```

`LedgerTransport` is the structural type `BaseApp` itself accepts, imported from `@zondax/ledger-js`.

> **A widening, not a break.** A hw-transport `Transport` satisfies `LedgerTransport`, so every existing caller compiles unchanged.

With the import gone, `@ledgerhq/hw-transport` (pinned at 6.31.9) is unreferenced and dropped.

## Verification

| check | result |
|---|---|
| `pnpm build` | pass |
| `pnpm lint` | pass |
| `pnpm test` | **8/8 pass** |

## Context worth having

Ledger Live's `live-signer-cosmos` pins this package at **exactly 3.0.3** against our published **4.0.1**, routed through a file literally named `LegacySignerCosmos.ts` — and depends on `@ledgerhq/device-signer-kit-cosmos` alongside it. Unrelated to this diff, but cosmos is where Ledger's own DMK signer kits overlap our territory most directly.

## ⚠️ CI is red, and expected to be

`@zondax/ledger-js` points at `github:Zondax/ledger-js#feat/dmk-transport` — the branch `LedgerTransport` comes from, not yet published. This repo's CI fails one step earlier than the typecheck: pnpm 11 refuses to run a git dependency's `prepare` script at all (`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED`), so the install itself errors. (An earlier version of this note blamed a mise `--ignore-scripts` flag — this repo's workflow doesn't use mise.) Nothing else in the diff fails CI; an adversarial review simulated the post-publish state by building that branch's `dist/` into `node_modules` and every check went green.

---

## On release day

[ledger-js#102](https://github.com/Zondax/ledger-js/pull/102) must ship as **`v2.0.0`** — it drops hw-transport from its own dependencies and narrows the exported `Transport` alias, which is a semver-major. So the one-line change here is:

```
"@zondax/ledger-js": "^2.0.0"
```

then reinstall. **The existing caret is not sufficient**: a frozen lockfile pins 1.3.x regardless, and the floor must exclude 1.3.4, which has no `LedgerTransport`.
