### PR TITLE
fix: point package.json repository.url at Zondax

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cosmos/ledger-cosmos-js.git"
+    "url": "git+https://github.com/Zondax/ledger-cosmos-js.git"
   },
   "license": "Apache-2.0",
   "author": "Zondax AG",


### PR DESCRIPTION
## Why

The `v4.1.0` publish failed with:

```
422 Unprocessable Entity
package.json: "repository.url" is "git+https://github.com/cosmos/ledger-cosmos-js.git",
expected to match "https://github.com/Zondax/ledger-cosmos-js" from provenance
```

`--provenance` requires `repository.url` to match the GitHub repo that ran the workflow. `homepage` and `bugs` already point at Zondax; only this field was still the old `cosmos/` URL.

`4.1.0` never landed on npm.

## What

```diff
- "url": "git+https://github.com/cosmos/ledger-cosmos-js.git"
+ "url": "git+https://github.com/Zondax/ledger-cosmos-js.git"
```

Same shape as `ledger-js` / `ledger-casper-js`.

## After merge

Re-running the failed workflow is not enough: `v4.1.0` still points at the old commit. Move the tag onto this merge and recreate the release:

```bash
gh release delete v4.1.0 --repo Zondax/ledger-cosmos-js --yes
git push origin :refs/tags/v4.1.0
git checkout master && git pull
git tag -f v4.1.0
git push origin v4.1.0
gh release create v4.1.0 --repo Zondax/ledger-cosmos-js --title v4.1.0 --generate-notes
```